### PR TITLE
Switch to alpine version of google/cloud-sdk:latest

### DIFF
--- a/gcloud/cloudrun/Dockerfile
+++ b/gcloud/cloudrun/Dockerfile
@@ -1,5 +1,5 @@
-FROM google/cloud-sdk:latest
-RUN apt-get update && apt-get install -y jq curl
+FROM google/cloud-sdk:alpine
+RUN apk --no-cache add jq curl
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/gcloud/pubsub/Dockerfile
+++ b/gcloud/pubsub/Dockerfile
@@ -1,5 +1,5 @@
-FROM google/cloud-sdk:latest
-RUN apt-get update && apt-get install -y jq curl
+FROM google/cloud-sdk:alpine
+RUN apk --no-cache add jq curl
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/now/Dockerfile
+++ b/now/Dockerfile
@@ -1,20 +1,10 @@
-FROM google/cloud-sdk:latest
+FROM google/cloud-sdk:alpine
 
-RUN apt-get update && \
-    apt-get install -y apt-transport-https curl lsb-release gnupg jq bash
-
-RUN DISTRO="$(lsb_release -s -c)" ; \
-    VERSION="node_12.x" ; \
-    curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo "deb https://deb.nodesource.com/$VERSION $DISTRO main" > /etc/apt/sources.list.d/nodesource.list && \
-    echo "deb-src https://deb.nodesource.com/$VERSION $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
-    apt-get update && \
-    apt-get install -y nodejs
-
-RUN npm config set unsafe-perm true
-RUN npm i -g npm now
-RUN curl -L https://storage.googleapis.com/berglas/master/linux_amd64/berglas -o /usr/local/bin/berglas
-RUN chmod +x /usr/local/bin/berglas
+RUN apk --no-cache add jq bash curl nodejs npm && \
+    npm config set unsafe-perm true && \
+    npm i -g npm now && \
+    curl -L https://storage.googleapis.com/berglas/master/linux_amd64/berglas -o /usr/local/bin/berglas && \
+    chmod +x /usr/local/bin/berglas
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR has been addressed to lower time spent during workflows. `google/cloud-sdk` provides `alpine` tag, which after building is 4 times smaller and it takes less time to download it.